### PR TITLE
fix: typo in mutations.tsv, lower -> upper

### DIFF
--- a/paper/mutations.tsv
+++ b/paper/mutations.tsv
@@ -1,4 +1,4 @@
-rank	mutation	mean/stddev	log10(P(ΔR > 1))	Δ log R	Δ log R 95% ci lower	Δ log R 95% ci upper	R / R_A	R / R_A 95% ci lower	R / R_A 95% ci lower	emerged in lineages
+rank	mutation	mean/stddev	log10(P(ΔR > 1))	Δ log R	Δ log R 95% ci lower	Δ log R 95% ci upper	R / R_A	R / R_A 95% ci lower	R / R_A 95% ci upper	emerged in lineages
 1	ORF1b:P314L	997.691	216149	0.17055	0.170215	0.170885	1.18596	1.18556	1.18635	B.1, B.59
 2	S:D614G	813.417	143678	0.128009	0.127701	0.128317	1.13656	1.13621	1.13691	A.18, A.19, A.2.5, B.1, B.4.8, B.59
 3	S:P681H	472.811	48546.4	0.0523829	0.0521658	0.0526001	1.05378	1.05355	1.05401	B.1.1.207, P.3 (B.1.1.28.3), B.1.1.318, B.1.1.336, B.1.1.338, B.1.1.351, B.1.1.465, B.1.1.519, B.1.1.522, B.1.1.7, B.1.243, B.1.469, B.1.474, B.1.530, B.1.575, B.1.620, B.1.621, B.1.623


### PR DESCRIPTION
Fix typo, the root cause may be deeper, I don't know how you generate this file.